### PR TITLE
Fixed bug causing libvirtd: End of file while reading data: Input/out…

### DIFF
--- a/prometheus-libvirt-exporter.go
+++ b/prometheus-libvirt-exporter.go
@@ -367,6 +367,8 @@ func CollectFromLibvirt(ch chan<- prometheus.Metric, uri string) error {
 		return err
 	}
 
+	defer l.Disconnect()
+
 	host, err := l.ConnectGetHostname()
 	if err != nil {
 		log.Fatalf("failed to get hostname: %v", err)


### PR DESCRIPTION
Closing the unix socket without first closing the libvirt connection causes recurring libvirt logmessages of the kind: 
2020-01-24 14:42:15.219+0000: 5688: error : virNetSocketReadWire:1806 : End of file while reading data: Input/output error
This should fix this problem.